### PR TITLE
delete lock buttons upon LockableKeys destruction

### DIFF
--- a/Source/lockable_keys.cpp
+++ b/Source/lockable_keys.cpp
@@ -48,6 +48,12 @@ LockableKeys::LockableKeys(juce::MidiKeyboardState& state, OnKeyLockStateChange 
     }
 }
 
+LockableKeys::~LockableKeys()
+{
+    for (auto &[midiNumber, lockButton]: lockButtons)
+        lockButton.deleteAndZero();
+}
+
 void LockableKeys::setLockButtonImage(ImageButtonPointer& lockButton, midi::MidiNumber midiNumber)
 {
    juce::Image unlockedImage = juce::ImageFileFormat::loadFrom(

--- a/Source/lockable_keys.h
+++ b/Source/lockable_keys.h
@@ -24,7 +24,7 @@ class LockableKeys: public juce::MidiKeyboardComponent
 public:
     LockableKeys(juce::MidiKeyboardState&, OnKeyLockStateChange);
 
-    ~LockableKeys() override {}
+    ~LockableKeys() override;
 
     void resized() override;
 


### PR DESCRIPTION
lock buttons (a vector of juce::Component::SafePointer<juce::ImageButton>) need to be manually deleted in the LockableKeys destructor