### PR TITLE
audio frames

### DIFF
--- a/Models/create_crepe_test_data.py
+++ b/Models/create_crepe_test_data.py
@@ -25,7 +25,7 @@ def downsample(audio, sample_rate):
   return resample(audio, sample_rate, CREPE_MODEL_SAMPLE_RATE).copy()
 
 def create_audio_frames(audio):
-  step_size = 1024
+  step_size = 10
   hop_length = int(CREPE_MODEL_SAMPLE_RATE * step_size / 1000)
   n_frames = 1 + int((len(audio) - 1024) / hop_length)
   frames = as_strided(

--- a/Source/pitch/crepe.h
+++ b/Source/pitch/crepe.h
@@ -13,14 +13,21 @@ namespace pitch_detection
     bool model_is_loaded();
 
     void load_model();
-    
+   
     float getFundementalFrequency(juce::AudioBuffer<float>&, int sampleRate);
 
+    // ------ the functions below are only exposed for testing purposes ------
+   
     #ifdef TESTMODE
-    void create1024SampleFrames(juce::AudioBuffer<float>&, int sampleRate);
-    void makeAudioMono(juce::AudioBuffer<float>& buffer);
-    void normalizeAudio(juce::AudioBuffer<float>&, int sampleRate);
-    juce::AudioBuffer<float> downSampleAudio(juce::AudioBuffer<float>&, int sampleRate);
+     
+      void makeAudioMono(juce::AudioBuffer<float>& buffer);
+
+      juce::AudioBuffer<float> downSampleAudio(juce::AudioBuffer<float>&, int sampleRate);
+
+      std::vector<std::vector<float>> create1024SampleFrames(juce::AudioBuffer<float>&, int sampleRate);
+     
+      std::vector<float> normalizeAudio(std::vector<std::vector<float>> sampleFrames);
+   
     #endif
 }
 


### PR DESCRIPTION
crepe model expects audio frames containing 1024 samples each.

This was the numpy/pandas implementation that I replicated:

```
hop_length = int(model_srate * step_size / 1000)
n_frames = 1 + int((len(audio) - 1024) / hop_length)
frames = as_strided(audio, shape=(1024, n_frames), strides=(audio.itemsize, hop_length * audio.itemsize))
frames = frames.transpose().copy()
```
